### PR TITLE
fatal error on error

### DIFF
--- a/lib/nodejs-mysql.js
+++ b/lib/nodejs-mysql.js
@@ -99,7 +99,6 @@ var MySQL = function () {
                     conn.query(sql, params, function (err, rows) {
                         if (err) {
                             console.error('query error!', err.stack ? err.stack : err);
-                            if (conn) conn.release();
                             return reject(err);
                         }
                         resolve(rows);

--- a/src/nodejs-mysql.js
+++ b/src/nodejs-mysql.js
@@ -53,7 +53,6 @@ export default class MySQL {
                 conn.query(sql, params, (err, rows) => {
                     if (err) {
                         console.error('query error!', err.stack ? err.stack : err)
-                        if (conn) conn.release()
                         return reject(err)
                     }
                     resolve(rows)


### PR DESCRIPTION
connection is already released by query() if exec() throws an error.